### PR TITLE
get tag number from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PyDrive==1.3.1
 requests==2.23.0
+beautifulsoup4==4.9.0
+bs4==0.0.1


### PR DESCRIPTION
Since the build step is to tag version number on GitHub then trigger the customized build script. 
It'll save an extra step to manually enter the tag number by pulling from GitHub. 